### PR TITLE
🚀 Update to version 1.7.6b

### DIFF
--- a/app.zen_browser.zen.yml
+++ b/app.zen_browser.zen.yml
@@ -44,21 +44,21 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.7.5b/zen.linux-x86_64.tar.xz
-        sha256: 591b50822055412993ac3b3049206fefad7de532bb9f9b573aecff9b8968581e
+        url: https://github.com/zen-browser/desktop/releases/download/1.7.6b/zen.linux-x86_64.tar.xz
+        sha256: 2278658c3a2b0b19970fd3826a0176454354f4babc848873ebf4ea47b4d2646e
         strip-components: 0
         only-arches:
           - x86_64
 
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.7.5b/zen.linux-aarch64.tar.xz
-        sha256: bb1b36768211e9aee58b920019ae1e5b8c0634ecaf75d2bdb220110aa75092f7
+        url: https://github.com/zen-browser/desktop/releases/download/1.7.6b/zen.linux-aarch64.tar.xz
+        sha256: 98dfc1f69d776f7052cfbc39fdd5b0ced18761e280fdbbd97b7c7985d1af7dfa
         strip-components: 0
         only-arches:
           - aarch64
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.7.5b/archive.tar
-        sha256: e04710c8bb8ad7c86ce2fe577eae7b202a6ccec9a0da07ac160214be06621e1f
+        url: https://github.com/zen-browser/flatpak/releases/download/1.7.6b/archive.tar
+        sha256: 70da179423051df5f99b54e64220c7a2c3a56fa90c052111638975ca2a3384d8
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.7.6b.

@mauro-balades please review and merge this PR.