### PR TITLE
Update manifest file

### DIFF
--- a/app.zen_browser.zen.yml
+++ b/app.zen_browser.zen.yml
@@ -28,7 +28,7 @@ finish-args:
   - --system-talk-name=org.freedesktop.NetworkManager
   - --talk-name=org.a11y.Bus
   - --env=GTK_PATH=/app/lib/gtkmodules
-  - --env=MESA_SHADER_CACHE_DIR=$XDG_RUNTIME_DIR/app/$FLATPAK_ID/cache/mesa_shader_cache_db
+  - --env=MESA_SHADER_CACHE_DIR=/var/cache/mesa_shader_cache_db
 modules:
   - name: zen_browser
     buildsystem: simple


### PR DESCRIPTION
Update variable `$MESA_SHADER_CACHE_DIR` to `/var/cache/` which is mounted at `~/.var/app/$FLATPAK_ID/cache.`  Solves [#3813](https://github.com/zen-browser/desktop/issues/3813)