### PR TITLE
Use Freedesktop SDK NSS library

### DIFF
--- a/app.zen_browser.zen.yml
+++ b/app.zen_browser.zen.yml
@@ -34,6 +34,7 @@ modules:
     buildsystem: simple
     build-commands:
       - mv zen /app/
+      - rm /app/zen/libnssckbi.so
       - mkdir -p /app/lib/ffmpeg
 
       - install -Dm0755 metadata/launch-script.sh ${FLATPAK_DEST}/bin/launch-script.sh


### PR DESCRIPTION
Fixes https://github.com/zen-browser/desktop/issues/7202

Rather than using the NSS library that's packaged with Zen, use the one provided by the freedesktop SDK. It is already available in the image at `/usr/lib/x86_64-linux-gnu/libnssckbi.so` so it's enough to just remove the one in `/app/zen`.

Using the freedesktop-provided library allows certificates trusted by the host system to also be trusted by Zen.