### PR TITLE
🚀 Update to version 1.12.2b

### DIFF
--- a/app.zen_browser.zen.yml
+++ b/app.zen_browser.zen.yml
@@ -44,8 +44,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.12.1b/zen.linux-x86_64.tar.xz
-        sha256: 95d8a2c6cf038b587e7859cc3f3b0f3d0bfb29fdb0210d997a96a590e7a7fdbc
+        url: https://github.com/zen-browser/desktop/releases/download/1.12.2b/zen.linux-x86_64.tar.xz
+        sha256: 37d5e6efee4faf9a087c74ef7302c13bb09d00618a1296702477b355cd53a2ee
         strip-components: 0
         only-arches:
           - x86_64
@@ -57,8 +57,8 @@ modules:
           is-main-source: true
 
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.12.1b/zen.linux-aarch64.tar.xz
-        sha256: b367ca645f35d7640e1497058a6f03aba4609382f6cd80baa005f785eef23273
+        url: https://github.com/zen-browser/desktop/releases/download/1.12.2b/zen.linux-aarch64.tar.xz
+        sha256: a478e34d7eb9685ffcf804e670260c62fd29f1974c87955fec5be7bc51da722a
         strip-components: 0
         only-arches:
           - aarch64
@@ -70,7 +70,7 @@ modules:
           is-main-source: true
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.12.1b/archive.tar
-        sha256: 7278b4b35a628f6d1c386da7d11ede34cd1779f1c6a25f02a4a52fa74936cccd
+        url: https://github.com/zen-browser/flatpak/releases/download/1.12.2b/archive.tar
+        sha256: 35f6bd6fa0393da0aba10d6271ac5abb7033190e98ae872db380fc3d6ca90af7
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.12.2b.

@mauro-balades please review and merge this PR.