### PR TITLE
🚀 Update to version 1.12.5b

### DIFF
--- a/app.zen_browser.zen.yml
+++ b/app.zen_browser.zen.yml
@@ -44,8 +44,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.12.4b/zen.linux-x86_64.tar.xz
-        sha256: c9b5ab9d13189fa1048088c04e69e84ec4ec61bf6660b34b60a49e4c1d9797a1
+        url: https://github.com/zen-browser/desktop/releases/download/1.12.5b/zen.linux-x86_64.tar.xz
+        sha256: ecc0d4f4966b6ba91fe21dcc673eb004bedc720e1cbe02e6c671fe2e8139a577
         strip-components: 0
         only-arches:
           - x86_64
@@ -57,8 +57,8 @@ modules:
           is-main-source: true
 
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.12.4b/zen.linux-aarch64.tar.xz
-        sha256: 7b36b605864a43a47e0dbc7f0b4550e02594df8790b50f3f43088a99a18c1593
+        url: https://github.com/zen-browser/desktop/releases/download/1.12.5b/zen.linux-aarch64.tar.xz
+        sha256: d0bc0dd7a2e317fc6a242644ae3142781aff62657bdba7d0d1410f7ce126e183
         strip-components: 0
         only-arches:
           - aarch64
@@ -70,7 +70,7 @@ modules:
           is-main-source: true
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.12.4b/archive.tar
-        sha256: 43be579e266fee2900a7ee51644cdc0d50f77446230357f0f011a966348fa8f5
+        url: https://github.com/zen-browser/flatpak/releases/download/1.12.5b/archive.tar
+        sha256: 9223d44913409655dfdd086c36ad074e1e2fb997802ac0cddb24a5ce34352a6b
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.12.5b.

@mauro-balades please review and merge this PR.