### PR TITLE
🚀 Update to version 1.12.6b

### DIFF
--- a/app.zen_browser.zen.yml
+++ b/app.zen_browser.zen.yml
@@ -44,8 +44,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.12.5b/zen.linux-x86_64.tar.xz
-        sha256: ecc0d4f4966b6ba91fe21dcc673eb004bedc720e1cbe02e6c671fe2e8139a577
+        url: https://github.com/zen-browser/desktop/releases/download/1.12.6b/zen.linux-x86_64.tar.xz
+        sha256: 0bf8d6a6ae95962860508f0c32ec29de0d2d67820ae5f8de4fdd7329eed60698
         strip-components: 0
         only-arches:
           - x86_64
@@ -57,8 +57,8 @@ modules:
           is-main-source: true
 
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.12.5b/zen.linux-aarch64.tar.xz
-        sha256: d0bc0dd7a2e317fc6a242644ae3142781aff62657bdba7d0d1410f7ce126e183
+        url: https://github.com/zen-browser/desktop/releases/download/1.12.6b/zen.linux-aarch64.tar.xz
+        sha256: 673e20c33f4ae5287a5c5ced839a5a55ea3b387d905565c009cd6b622dc1c15c
         strip-components: 0
         only-arches:
           - aarch64
@@ -70,7 +70,7 @@ modules:
           is-main-source: true
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.12.5b/archive.tar
-        sha256: 9223d44913409655dfdd086c36ad074e1e2fb997802ac0cddb24a5ce34352a6b
+        url: https://github.com/zen-browser/flatpak/releases/download/1.12.6b/archive.tar
+        sha256: 65d8f29a011af52d6ff739dcf6011d165ccb5f99542668b77c8aa2491167602a
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.12.6b.

@mauro-balades please review and merge this PR.