### PR TITLE
🚀 Update to version 1.12.8b

### DIFF
--- a/app.zen_browser.zen.yml
+++ b/app.zen_browser.zen.yml
@@ -44,8 +44,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.12.7b/zen.linux-x86_64.tar.xz
-        sha256: d7f25e56a0c7a27c1e121c5470bb43cc9dbafb45a4c6a762f835ddfc5972bed2
+        url: https://github.com/zen-browser/desktop/releases/download/1.12.8b/zen.linux-x86_64.tar.xz
+        sha256: 1ceac5b079de3026fd7ce195d791d6553362c98b4422a3bf98657e34daa357c7
         strip-components: 0
         only-arches:
           - x86_64
@@ -57,8 +57,8 @@ modules:
           is-main-source: true
 
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.12.7b/zen.linux-aarch64.tar.xz
-        sha256: 4d66b1ef9dc02f1cca21a7c1141a023d65cb0dd18133f8ecfd8b23d937c3b145
+        url: https://github.com/zen-browser/desktop/releases/download/1.12.8b/zen.linux-aarch64.tar.xz
+        sha256: deaec445e8eef3a33a41a8582ce1749865467764bc7d1364a9ab4e5fbd06a015
         strip-components: 0
         only-arches:
           - aarch64
@@ -70,7 +70,7 @@ modules:
           is-main-source: true
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.12.7b/archive.tar
-        sha256: e3add5cf8db2271aa2487af6467d5ed1d8d53605ad73aaa7062a34a96e8c20f0
+        url: https://github.com/zen-browser/flatpak/releases/download/1.12.8b/archive.tar
+        sha256: ee5bb7c6b017158ed9041399edc10cbacfc3948f043fb753302f7de918dfdfa1
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.12.8b.

@mauro-balades please review and merge this PR.