### PR TITLE
Update to version `1.16.1b`

### DIFF
--- a/app.zen_browser.zen.yml
+++ b/app.zen_browser.zen.yml
@@ -1,13 +1,13 @@
 app-id: app.zen_browser.zen
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 base: org.mozilla.firefox.BaseApp
-base-version: '24.08'
+base-version: '25.08'
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
-    version: '24.08'
+    version: '25.08'
     add-ld-path: .
   app.zen_browser.zen.systemconfig:
     directory: etc/zen
@@ -32,7 +32,6 @@ finish-args:
   - --system-talk-name=org.freedesktop.NetworkManager
   - --talk-name=org.a11y.Bus
   - --talk-name=org.gtk.vfs.*
-  - --talk-name=org.freedesktop.Notifications
   - --own-name=org.mpris.MediaPlayer2.firefox.*
   - --own-name=org.mozilla.zen.*
 cleanup:
@@ -63,8 +62,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.16b/zen.linux-x86_64.tar.xz
-        sha256: 0ac167604da447bef9a90e8cdf537f359cb2fe95a1cfe2f72a66966b7c3e5209
+        url: https://github.com/zen-browser/desktop/releases/download/1.16.1b/zen.linux-x86_64.tar.xz
+        sha256: 7964e7a1cb25457ba4617a42608b4a8f73a2dccd92d31da298de02fb3468d66e
         strip-components: 0
         only-arches:
           - x86_64
@@ -76,8 +75,8 @@ modules:
           is-main-source: true
 
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.16b/zen.linux-aarch64.tar.xz
-        sha256: ad10d4e28fedf25f64e2afec354c25a2b60a8e795f3e7dadb488e1e232db64fd
+        url: https://github.com/zen-browser/desktop/releases/download/1.16.1b/zen.linux-aarch64.tar.xz
+        sha256: d5350a9410bf57287fcca523ade1a67f7bbb61c103560b3fae6d54b975901e27
         strip-components: 0
         only-arches:
           - aarch64
@@ -89,7 +88,7 @@ modules:
           is-main-source: true
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.16b/archive.tar
-        sha256: 9b658cd0dc3431d1562c6f119820392086a9e82419309aad356097bbc84a7054
+        url: https://github.com/zen-browser/flatpak/releases/download/1.16.1b/archive.tar
+        sha256: c013868847c134c0cd977f0f03311e6a125510b6de15b4c4e9c4cf703d047b2e
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.16.1b.

@mr-cheffy please review and merge this PR.