### PR TITLE
Update to version `1.18.8b`

### DIFF
--- a/app.zen_browser.zen.yml
+++ b/app.zen_browser.zen.yml
@@ -62,12 +62,6 @@ modules:
         strip-components: 0
         only-arches:
           - x86_64
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/zen-browser/desktop/releases/latest
-          version-query: .tag_name
-          url-query: .assets[] | select(.name=="zen.linux-x86_64.tar.xz") | .browser_download_url
-          is-main-source: true
 
       - type: archive
         url: https://github.com/zen-browser/desktop/releases/download/1.18.8b/zen.linux-aarch64.tar.xz
@@ -75,12 +69,6 @@ modules:
         strip-components: 0
         only-arches:
           - aarch64
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/zen-browser/desktop/releases/latest
-          version-query: .tag_name
-          url-query: .assets[] | select(.name=="zen.linux-aarch64.tar.xz") | .browser_download_url
-          is-main-source: true
 
       - type: archive
         url: https://github.com/zen-browser/flatpak/releases/download/1.18.8b/archive.tar


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.18.8b.

@mr-cheffy please review and merge this PR.